### PR TITLE
Remove `tl_article` ptable requirement in `ContentChildRecordCallbackListener`

### DIFF
--- a/src/EventListener/ContentChildRecordCallbackListener.php
+++ b/src/EventListener/ContentChildRecordCallbackListener.php
@@ -22,10 +22,6 @@ class ContentChildRecordCallbackListener
         // Render child record
         $childRecord = (new \tl_content())->addCteType($row);
 
-        if ('tl_article' !== $row['ptable']) {
-            return $childRecord;
-        }
-
         // Get the content element
         $element = ContentModel::findById((int) $row['id']);
 


### PR DESCRIPTION
Correct me if I'm wrong, but I don't think this is necessary?

This currently prevents the include info to be displayed on content elements in news, terminal42/contao-node (which is where I particularly need it for a customer 😄 ), etc.

Without the check for the ptable it's already working as is for news and terminal42/contao-node and should work everywhere else, too.