### PR TITLE
Add ptable in url, when required

### DIFF
--- a/src/Aggregator/IncludesAggregator.php
+++ b/src/Aggregator/IncludesAggregator.php
@@ -336,6 +336,7 @@ final class IncludesAggregator
             'do' => $do,
             'id' => $id,
             'table' => $table,
+            'ptable' => $record['ptable'] ?? null,
             'ref' => $this->requestStack->getCurrentRequest()->attributes->get('_contao_referer_id'),
         ];
 


### PR DESCRIPTION
I've a referenced Content element inside an Element-Group (Content Element). The link path under Include info now works correctly, as it requires `ptable` info also.